### PR TITLE
端末の設定アプリから起動できる様修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
端末の設定のアプリ情報から起動できる様に修正しました。

殆どの場合、これは必要無いですが、LINEアプリからのみこのアクティビティを開けるように将来的に変更を加える場合を想定して、先に追加しておきます。  
LINEアプリが動作しなくなった時に回避策として使えます。