### PR TITLE
proguard-rules.pro の中身を削除

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,1 @@
--keep de.robv.android.xposed.**
+


### PR DESCRIPTION
`compileOnly`は難読化されません。  
そもそも書き方が間違っていました。