### PR TITLE
arrays.xml を削除

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
             android:value="true" />
         <meta-data
             android:name="xposedscope"
-            android:resource="@array/xposed_scope" />
+            android:value="jp.naver.line.android" />
     </application>
 
 </manifest>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,5 +1,0 @@
-<resources>
-    <string-array name="xposed_scope">
-        <item>jp.naver.line.android</item>
-    </string-array>
-</resources>


### PR DESCRIPTION
#33 の追加修正です。

今後、`jp.naver.line.android` 以外に追加される事は無いと思うので、マニフェストに直で書く方式にしました。

以後、追加される場合があっても、セミコロンを付けるだけで良いので大丈夫かと思います。

<https://github.com/LSPosed/LSPosed/wiki/Module-Scope#example-usage>
