### PR TITLE
Android Studio が赤く染まる原因を削除

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,5 +62,4 @@ dependencies {
     //noinspection GradleCompatible
     implementation 'com.android.support:customtabs:27.0.1'
     compileOnly 'de.robv.android.xposed:api:82'
-    compileOnly 'de.robv.android.xposed:api:82:sources'
 }


### PR DESCRIPTION
### 確認項目

<!--
以下の項目を全て確認し、満たしている場合は
[ ] を [x] に書き換えてください。
該当部分以外は書き換えないでください。
-->

- [x] <!-- Choice,multiple --> 動作確認済み
- [x] <!-- Choice,multiple --> 誤字脱字無し

---
### 説明
<!--
プルリクエストの詳細を記述してください。
-->
xposed 関係のライブラリが正常に読み込まれない問題を修正