### PR TITLE
minSdk を Pie (Android 9.0) に引き上げ

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdk 26
+        minSdk 28
         //noinspection OldTargetApi
         targetSdk 33
         versionCode 10


### PR DESCRIPTION
### 確認項目

<!--
以下の項目を全て確認し、満たしている場合は
[ ] を [x] に書き換えてください。
該当部分以外は書き換えないでください。
-->

- [x] <!-- Choice,multiple --> 動作確認済み
- [x] <!-- Choice,multiple --> 誤字脱字無し

---
### 説明
<!--
プルリクエストの詳細を記述してください。
-->
LINE 14.5.x 以降は、Oreo (Android 8.0, 8.1) はサポートされていません。