### PR TITLE
リソースid変更に伴ってリダイレクトで開かないようになったため訂正

### DIFF
--- a/app/src/main/java/io/github/chipppppppppp/lime/hooks/RedirectWebView.java
+++ b/app/src/main/java/io/github/chipppppppppp/lime/hooks/RedirectWebView.java
@@ -26,16 +26,15 @@ public class RedirectWebView implements IHook {
                     @Override
                     protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                         Activity activity = (Activity) param.thisObject;
-                        
                         View rootView = activity.getWindow().getDecorView().getRootView();
                         WebView webView = findWebView(rootView);
 
                         if (webView != null) {
                             webView.setVisibility(View.GONE);
                             webView.stopLoading();
-                            
+
                             Uri uri = Uri.parse(webView.getUrl());
-                            
+
                             if (limeOptions.openInBrowser.checked) {
                                 Intent intent = new Intent(Intent.ACTION_VIEW);
                                 intent.setData(uri);
@@ -47,7 +46,7 @@ public class RedirectWebView implements IHook {
                                         .build();
                                 tabsIntent.launchUrl(activity, uri);
                             }
-                         
+
                             activity.finish();
 
                         }
@@ -55,6 +54,7 @@ public class RedirectWebView implements IHook {
                 }
         );
     }
+
     private WebView findWebView(View view) {
         if (view instanceof WebView) {
             return (WebView) view;


### PR DESCRIPTION
リソースid変更に伴ってリダイレクトで開かないようになったためコードの訂正

### 確認項目

<!--
以下の項目を全て確認し、満たしている場合は
[ ] を [x] に書き換えてください。
該当部分以外は書き換えないでください。
-->

- [ ] <!-- Choice,multiple --> 動作確認済み
- [ ] <!-- Choice,multiple --> 誤字脱字無し

---
### 説明
既定のブラウザにリダイレクトのバグを修正

この機能使わないので気づけませんでしたすみません